### PR TITLE
Simplify notification profile views

### DIFF
--- a/src/aas/site/alert/urls.py
+++ b/src/aas/site/alert/urls.py
@@ -7,5 +7,5 @@ app_name = "alert"
 urlpatterns = [
     path("all/", views.all_alerts_view, name="all"),
     # path("create/", login_required(views.CreateAlertView.as_view()), name="create"),
-    path("source/<int:source_pk>/", views.all_alerts_from_source_view, name="source"),
+    path("source/<int:source_pk>", views.all_alerts_from_source_view, name="source"),
 ]

--- a/src/aas/site/notificationprofile/permissions.py
+++ b/src/aas/site/notificationprofile/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework import permissions
+
+
+class IsOwner(permissions.BasePermission):
+    def has_object_permission(self, request, view, notification_profile):
+        return notification_profile.user == request.user

--- a/src/aas/site/notificationprofile/serializers.py
+++ b/src/aas/site/notificationprofile/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import NotificationProfile
+
+
+class NotificationProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = NotificationProfile
+        fields = ['user', 'name', 'interval_start', 'interval_stop']

--- a/src/aas/site/notificationprofile/serializers.py
+++ b/src/aas/site/notificationprofile/serializers.py
@@ -6,4 +6,6 @@ from .models import NotificationProfile
 class NotificationProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = NotificationProfile
-        fields = ['user', 'name', 'interval_start', 'interval_stop']
+        fields = ['pk', 'name', 'interval_start', 'interval_stop']
+
+    pk = serializers.ReadOnlyField()

--- a/src/aas/site/notificationprofile/urls.py
+++ b/src/aas/site/notificationprofile/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 app_name = "notificationprofile"
 urlpatterns = [
-    path("", views.NotificationProfileView.as_view()),
-    path("<int:profile_id>", views.NotificationProfileView.as_view()),
+    path("", views.NotificationProfileList.as_view()),
+    path("<int:pk>", views.NotificationProfileDetail.as_view()),
     path("alerts/", views.notification_profile_alerts_view),
 ]

--- a/src/aas/site/notificationprofile/urls.py
+++ b/src/aas/site/notificationprofile/urls.py
@@ -4,8 +4,7 @@ from . import views
 
 app_name = "notificationprofile"
 urlpatterns = [
-    path("alerts/", views.notification_profile_alerts_view, name="notification_profile_alerts"),
-    path("create/", views.create_notification_profile_view, name="create_notification_profile"),
-    path("delete/<int:profile_id>", views.delete_notification_profile_view, name="delete_notification_profile"),
-    path("all/", views.get_notification_profiles_view, name="get_notification_profiles"),
+    path("", views.NotificationProfileView.as_view()),
+    path("<int:profile_id>", views.NotificationProfileView.as_view()),
+    path("alerts/", views.notification_profile_alerts_view),
 ]

--- a/src/aas/site/notificationprofile/views.py
+++ b/src/aas/site/notificationprofile/views.py
@@ -1,51 +1,32 @@
 from django.core import serializers
-from django.http import Http404, HttpResponse
-from rest_framework import status
-from rest_framework.authentication import TokenAuthentication
+from django.http import HttpResponse
+from rest_framework import generics
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.renderers import JSONRenderer
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from aas.site.alert.models import Alert
 from .models import NotificationProfile
+from .permissions import IsOwner
 from .serializers import NotificationProfileSerializer
 
 
-class NotificationProfileView(APIView):
-    renderer_classes = [JSONRenderer]
-    parser_classes = [JSONParser]
-    authentication_classes = [TokenAuthentication]
-    permission_classes = [IsAuthenticated]
+class NotificationProfileList(generics.ListCreateAPIView):
+    permission_classes = [IsAuthenticated, IsOwner]
+    serializer_class = NotificationProfileSerializer
 
-    def get(self, request):
-        notification_profiles = request.user.notification_profiles.all()
-        serializer = NotificationProfileSerializer(notification_profiles, many=True)
-        return Response(serializer.data)
+    def get_queryset(self):
+        return self.request.user.notification_profiles.all()
 
-    def post(self, request):
-        new_profile = NotificationProfile()
-        new_profile.user = request.user
-        new_profile.interval_start = request.POST.get("start")
-        new_profile.interval_stop = request.POST.get("end")
-        new_profile.save()
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
 
-        serializer = NotificationProfileSerializer(new_profile)
-        return Response(serializer.data)
 
-    def delete(self, request, profile_id):
-        profile = self.get_object(profile_id)
-        profile.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+class NotificationProfileDetail(generics.RetrieveUpdateDestroyAPIView):
+    permission_classes = [IsAuthenticated, IsOwner]
+    serializer_class = NotificationProfileSerializer
 
-    @staticmethod
-    def get_object(pk):
-        try:
-            return NotificationProfile.objects.get(pk=pk)
-        except NotificationProfile.DoesNotExist:
-            raise Http404
+    def get_queryset(self):
+        return self.request.user.notification_profiles.all()
 
 
 @api_view(['GET'])

--- a/src/aas/site/notificationprofile/views.py
+++ b/src/aas/site/notificationprofile/views.py
@@ -1,10 +1,51 @@
 from django.core import serializers
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
+from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from aas.site.alert.models import Alert
 from .models import NotificationProfile
+from .serializers import NotificationProfileSerializer
+
+
+class NotificationProfileView(APIView):
+    renderer_classes = [JSONRenderer]
+    parser_classes = [JSONParser]
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        notification_profiles = request.user.notification_profiles.all()
+        serializer = NotificationProfileSerializer(notification_profiles, many=True)
+        return Response(serializer.data)
+
+    def post(self, request):
+        new_profile = NotificationProfile()
+        new_profile.user = request.user
+        new_profile.interval_start = request.POST.get("start")
+        new_profile.interval_stop = request.POST.get("end")
+        new_profile.save()
+
+        serializer = NotificationProfileSerializer(new_profile)
+        return Response(serializer.data)
+
+    def delete(self, request, profile_id):
+        profile = self.get_object(profile_id)
+        profile.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @staticmethod
+    def get_object(pk):
+        try:
+            return NotificationProfile.objects.get(pk=pk)
+        except NotificationProfile.DoesNotExist:
+            raise Http404
 
 
 @api_view(['GET'])
@@ -18,35 +59,6 @@ def notification_profile_alerts_view(request):
             if is_between(alert=alert, profile=profile):
                 data.append(alert)
     json_result = serializers.serialize("json", data)
-    return HttpResponse(json_result, content_type="application/json")
-
-
-@api_view(['POST'])
-@permission_classes([IsAuthenticated])
-def create_notification_profile_view(request):
-    new_profile = NotificationProfile()
-    new_profile.user = request.user
-    new_profile.interval_start = request.POST.get("start")
-    new_profile.interval_stop = request.POST.get("end")
-    new_profile.save()
-
-    json_result = serializers.serialize("json", [new_profile])
-    return HttpResponse(json_result, content_type="application/json")
-
-
-@api_view(['DELETE'])
-@permission_classes([IsAuthenticated])
-def delete_notification_profile_view(request, profile_id):
-    profile_to_delete = NotificationProfile.objects.get(pk=profile_id)
-    json_result = serializers.serialize("json", [profile_to_delete])
-    profile_to_delete.delete()
-    return HttpResponse(json_result, content_type="application/json")
-
-
-@api_view(['GET'])
-@permission_classes([IsAuthenticated])
-def get_notification_profiles_view(request):
-    json_result = serializers.serialize("json", request.user.notification_profiles.all())
     return HttpResponse(json_result, content_type="application/json")
 
 

--- a/src/aas/site/settings/base.py
+++ b/src/aas/site/settings/base.py
@@ -91,6 +91,12 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
+    'DEFAULT_PARSER_CLASSES': (
+        'rest_framework.parsers.JSONParser',
+    ),
 }
 
 

--- a/src/aas/site/urls.py
+++ b/src/aas/site/urls.py
@@ -29,8 +29,8 @@ urlpatterns = [
 
     path('', RedirectView.as_view(url="http://localhost:3000"), name='index'),  # temporary URL
     path('', include('aas.site.auth.urls')),
-    path('alert/', include('aas.site.alert.urls')),
-    path('notificationprofile/', include('aas.site.notificationprofile.urls')),
+    path('alerts/', include('aas.site.alert.urls')),
+    path('notificationprofiles/', include('aas.site.notificationprofile.urls')),
 ]
 
 urlpatterns += [


### PR DESCRIPTION
### Updated endpoints:
- `GET` to `notificationprofiles/`: returns the logged in user's notification profiles
- `POST` to `notificationprofiles/`: creates and returns a notification profile
  - Body needs `{ name: "tjalve_360No_Scope", interval_start: "2018-06-12 09:55:22", interval_stop: "2018-06-12 09:55:22" }`
- `GET` to `notificationprofiles/<int:pk>`: returns the notification profile with the provided pk
- `PUT` to `notificationprofiles/<int:pk>`: updates and returns the notification profile with the provided pk
  - Body needs `{ name: "tjalve_420Missed_It", interval_start: "2018-06-12 09:55:22", interval_stop: "2018-06-12 09:55:22" }`
- `DELETE` to `notificationprofiles/<int:pk>`: deletes the notification profile with the provided pk