### PR TITLE
Redirect to frontend with token + user serialization

### DIFF
--- a/src/aas/dataporten/views.py
+++ b/src/aas/dataporten/views.py
@@ -1,0 +1,24 @@
+from django.shortcuts import redirect
+from django.conf import settings
+from rest_framework.authtoken.models import Token
+from social_django import views as social_views
+
+
+def login_wrapper(request, backend, *args, **kwargs):
+    # Needs to be called to fetch the user's social data
+    _response = social_views.complete(request, backend, *args, **kwargs)
+
+    user = request.user
+    data = user.social_auth.first().extra_data
+
+    if not user.get_full_name():
+        # Update the full name of the user
+        user.first_name = ' '.join(data['fullname'].split()[:-1])
+        user.last_name = data['fullname'].split()[-1]
+
+        user.save()
+
+    token, _created = Token.objects.get_or_create(user=user)
+    response = redirect(settings.FRONTEND_URL, permanent=True)
+    response['token'] = token.key
+    return response

--- a/src/aas/dataporten/views.py
+++ b/src/aas/dataporten/views.py
@@ -20,5 +20,5 @@ def login_wrapper(request, backend, *args, **kwargs):
 
     token, _created = Token.objects.get_or_create(user=user)
     response = redirect(settings.FRONTEND_URL, permanent=True)
-    response['token'] = token.key
+    response.set_cookie('token', token.key)
     return response

--- a/src/aas/dataporten/views.py
+++ b/src/aas/dataporten/views.py
@@ -1,11 +1,11 @@
-from django.shortcuts import redirect
 from django.conf import settings
+from django.shortcuts import redirect
 from rest_framework.authtoken.models import Token
 from social_django import views as social_views
 
 
 def login_wrapper(request, backend, *args, **kwargs):
-    # Needs to be called to fetch the user's social data
+    # Needs to be called to fetch the user's Feide data (available through `social_auth`)
     _response = social_views.complete(request, backend, *args, **kwargs)
 
     user = request.user

--- a/src/aas/site/alert/fixtures/generate_fixtures.py
+++ b/src/aas/site/alert/fixtures/generate_fixtures.py
@@ -152,8 +152,9 @@ def generate_objects(object_types, network_systems) -> List[Model]:
 
     objects = []
     for _ in range(NUM_OBJECTS):
-        name_words = []
 
+        # Generate name
+        name_words = []
         for _ in range(random_int(OBJECT_NAME_WORD_COUNT_RANGE)):
             if roll_dice(COMPOSITE_WORD_CHANCE):
                 # Will be a word-like-this
@@ -161,9 +162,9 @@ def generate_objects(object_types, network_systems) -> List[Model]:
             else:
                 word = random_object_word().title()
             name_words.append(word)
+        name = " ".join(name_words)
 
         network_system = random.choice(network_systems)
-        name = " ".join(name_words)
 
         objects.append(Object(
             name=name,

--- a/src/aas/site/auth/serializers.py
+++ b/src/aas/site/auth/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import User
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['username', 'first_name', 'last_name', 'email']

--- a/src/aas/site/auth/urls.py
+++ b/src/aas/site/auth/urls.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import views
-
+from . import views as auth_views
 from django.urls import path
 
 app_name = 'auth'
@@ -11,4 +11,8 @@ urlpatterns = [
     path('logout/',
          views.LogoutView.as_view(),
          name='logout'),
+
+    path('user/',
+         auth_views.get_user,
+         name='user'),
 ]

--- a/src/aas/site/auth/urls.py
+++ b/src/aas/site/auth/urls.py
@@ -1,18 +1,19 @@
-from django.contrib.auth import views
-from . import views as auth_views
+from django.contrib.auth import views as django_views
 from django.urls import path
+
+from . import views
 
 app_name = 'auth'
 urlpatterns = [
     path('login/',
-         views.LoginView.as_view(template_name='auth/login.html', redirect_authenticated_user=True),
+         django_views.LoginView.as_view(template_name='auth/login.html', redirect_authenticated_user=True),
          name='login'),
 
     path('logout/',
-         views.LogoutView.as_view(),
+         django_views.LogoutView.as_view(),
          name='logout'),
 
     path('user/',
-         auth_views.get_user,
+         views.get_user,
          name='user'),
 ]

--- a/src/aas/site/auth/views.py
+++ b/src/aas/site/auth/views.py
@@ -1,11 +1,12 @@
-from django.http import HttpResponse
-from django.core import serializers
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from .serializers import UserSerializer
 
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def get_user(request):
-    data = serializers.serialize("json", [request.user])
-    return HttpResponse(data, content_type="application/json")
+    serializer = UserSerializer(request.user)
+    return Response(serializer.data)

--- a/src/aas/site/auth/views.py
+++ b/src/aas/site/auth/views.py
@@ -1,0 +1,11 @@
+from django.http import HttpResponse
+from django.core import serializers
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_user(request):
+    data = serializers.serialize("json", [request.user])
+    return HttpResponse(data, content_type="application/json")

--- a/src/aas/site/settings/base.py
+++ b/src/aas/site/settings/base.py
@@ -158,16 +158,9 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 
-CORS_ORIGIN_WHITELIST = [
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
-]
-
-
 AUTHENTICATION_BACKENDS = (
-    'dataporten.social.DataportenFeideOAuth2',
-    'dataporten.social.DataportenEmailOAuth2',
-    'dataporten.social.DataportenOAuth2',
+    'aas.dataporten.social.DataportenFeideOAuth2',
+    'aas.dataporten.social.DataportenOAuth2',
     'django.contrib.auth.backends.ModelBackend',
 )
 

--- a/src/aas/site/settings/dev.py
+++ b/src/aas/site/settings/dev.py
@@ -1,3 +1,9 @@
 from .base import *
 
-# Add overrides here
+
+FRONTEND_URL = "http://localhost:3000"
+
+CORS_ORIGIN_WHITELIST = [
+    FRONTEND_URL,
+    "http://127.0.0.1:3000",
+]

--- a/src/aas/site/settings/prod.py
+++ b/src/aas/site/settings/prod.py
@@ -2,4 +2,10 @@ from .base import *
 
 DEBUG = False
 
-# Add overrides here
+
+# TODO: set this
+FRONTEND_URL = None
+
+CORS_ORIGIN_WHITELIST = [
+    FRONTEND_URL,
+]

--- a/src/aas/site/urls.py
+++ b/src/aas/site/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
 
     path('', include('aas.site.auth.urls')),
     path('alert/', include('aas.site.alert.urls')),
+    path('auth/', include('aas.site.auth.urls'))
 ]
 
 urlpatterns += [

--- a/src/aas/site/urls.py
+++ b/src/aas/site/urls.py
@@ -14,24 +14,24 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path
-from django.views.generic import TemplateView, RedirectView
+from django.urls import include, path, re_path
 from rest_framework.authtoken import views as rest_views
+from social_django.urls import extra
 
 from . import views as aas_views
+from aas.dataporten import views as dataporten_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 
-   # path('dataporten/', TemplateView.as_view(template_name='dataporten.html'), name='dataporten'),
-    path('dataporten/', RedirectView.as_view(url="http://localhost:3000"), name='dataporten'),
-    path('api-token-auth/', rest_views.obtain_auth_token, name='api-token-auth'),
-
-    path('', RedirectView.as_view(url="http://localhost:3000"), name='index'),  # temporary URL
     path('', include('aas.site.auth.urls')),
     path('alert/', include('aas.site.alert.urls')),
 ]
 
 urlpatterns += [
+    path('api-token-auth/', rest_views.obtain_auth_token, name='api-token-auth'),
+
+    # Overrides social_django's `complete` view
+    re_path(r'^complete/(?P<backend>[^/]+){0}$'.format(extra), dataporten_views.login_wrapper, name='complete'),
     path('', include('social_django.urls', namespace='social')),
 ]

--- a/src/aas/site/urls.py
+++ b/src/aas/site/urls.py
@@ -18,15 +18,13 @@ from django.urls import include, path, re_path
 from rest_framework.authtoken import views as rest_views
 from social_django.urls import extra
 
-from . import views as aas_views
 from aas.dataporten import views as dataporten_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 
-    path('', include('aas.site.auth.urls')),
+    path('auth/', include('aas.site.auth.urls')),
     path('alert/', include('aas.site.alert.urls')),
-    path('auth/', include('aas.site.auth.urls'))
 ]
 
 urlpatterns += [


### PR DESCRIPTION
When logging in through Feide, one is now redirected to backend, which in turn redirects to frontend together with a cookie containing the user's authentication token.

#### New endpoint:
- `GET` to `auth/user/`: returns the logged in user's info