### PR TITLE
Add endpoint for posting alerts

### DIFF
--- a/src/aas/site/alert/serializers.py
+++ b/src/aas/site/alert/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from .models import Alert
+
+
+class AlertSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Alert
+        fields = ['pk', 'timestamp', 'source', 'alert_id', 'object', 'parent_object', 'details_url', 'problem_type', 'description']
+        read_only_fields = ['pk']

--- a/src/aas/site/alert/urls.py
+++ b/src/aas/site/alert/urls.py
@@ -1,11 +1,10 @@
-from django.contrib.auth.decorators import login_required
 from django.urls import path
 
 from . import views
 
 app_name = "alert"
 urlpatterns = [
-    path("all/", views.all_alerts_view, name="all"),
+    path("", views.AlertList.as_view()),
     # path("create/", login_required(views.CreateAlertView.as_view()), name="create"),
     path("source/<int:source_pk>", views.all_alerts_from_source_view, name="source"),
 ]

--- a/src/aas/site/alert/views.py
+++ b/src/aas/site/alert/views.py
@@ -3,24 +3,21 @@ import json
 from django.core import serializers
 from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic import FormView
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework import generics
 
 from .forms import AlertJsonForm
 from .models import Alert
+from .serializers import AlertSerializer
 
 
-@api_view(['GET'])
-@permission_classes([IsAuthenticated])
-def all_alerts_view(request):
-    # json_result = json_utils.alert_hists_to_json(AlertHistory.objects.all())
-    data = serializers.serialize("json", Alert.objects.all())
-    json_result = json.dumps(json.loads(data), indent=4)
-    return HttpResponse(json_result, content_type="application/json")
+class AlertList(generics.ListCreateAPIView):
+    queryset = Alert.objects.all()
+    serializer_class = AlertSerializer
 
 
 def all_alerts_from_source_view(request, source_pk):
     data = serializers.serialize("json", Alert.objects.filter(source=source_pk))
+    # Prettify the JSON data:
     json_result = json.dumps(json.loads(data), indent=4)
     return HttpResponse(json_result, content_type="application/json")
 

--- a/src/aas/site/notificationprofile/serializers.py
+++ b/src/aas/site/notificationprofile/serializers.py
@@ -7,5 +7,4 @@ class NotificationProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = NotificationProfile
         fields = ['pk', 'name', 'interval_start', 'interval_stop']
-
-    pk = serializers.ReadOnlyField()
+        read_only_fields = ['pk']


### PR DESCRIPTION
### New endpoint:
- `POST` to `/alerts/`: creates and returns an alert
  - Body has to be in the following format **(Remember to change `alert_id` to something unique for each `POST` request!)**:
  ```
  {
      "timestamp": "2011-06-18 16:09:54",
      "source": 1,
      "alert_id": "594897",
      "object": 6,
      "parent_object": 10,
      "details_url": "http://t6.nav.no/594897",
      "problem_type": 4,
      "description": "Zycl hmvte ktm fuedesc."
  }
  ```
  ***Tip:** The `fields` object of each generated mock alert can be directly copied and posted to this endpoint, as long as `alert_id` is changed or the corresponding alert is deleted from the database.*

### Updated endpoint:
- `GET` to `/alerts/` (instead of `/alerts/all`): returns all alerts

### The alerts JSON now has a different format:
Alerts' fields are no longer wrapped inside a `fields` object. Instead, the fields are serialized into their own complete JSON objects.

As an example, this is how each alert was previously formatted:
```
{
    "model": "alert.alert",
        "pk": 123,
        "fields": {
            "timestamp": ...
            ...
        }
}
```
and this is how each alert is currently formatted:
```
{
    "pk": 123,
    "timestamp": ...
    ...
}
```